### PR TITLE
Implement multi-transport communication strategy

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,9 +35,10 @@ This document describes the current, implemented architecture of Neorest.
 ### Client (`neorest`)
 
 - **Client** (`packages/neorest/src/Client.ts`)
-  - Constructor: `new Client(url, strategyType = 'websocket', options?)`
+  - Constructor: `new Client(url, strategyType = 'auto', options?)`
   - Methods: `get`, `post`, `delete`, `postAndForget`, `on(route, cb)`, `off(route)`, `isConnected`, `getURL`, `setUrl`
   - Delegates to `ClientConnection`
+  - Default strategy is `auto` which connects via HTTP long‑polling first, then upgrades to WebSocket when available
 
 - **ClientConnection**
   - Extends `ConnectionBase`
@@ -51,6 +52,7 @@ This document describes the current, implemented architecture of Neorest.
   - WebSocket: Uses browser `WebSocket`; forwards messages and lifecycle events
   - HTTP long‑polling: Handshake to obtain `clientId`, `POST` to send, `GET ?poll=true` to receive queued messages
     - Adds auth headers if provided via `setAuthentication`
+  - Auto: Starts over HTTP long‑polling for immediate connectivity, attempts a background WebSocket upgrade, and prefers WS for sending once connected; if WS send fails, falls back to HTTP `POST` transparently. Receives messages from whichever transports are active.
 
 ### Router Core (`@neorest/router-core`)
 
@@ -79,10 +81,11 @@ This document describes the current, implemented architecture of Neorest.
 - **NodeServerAdapter**
   - Creates HTTP/HTTPS server
   - Tries to enable WebSocket if `ws` is installed (dynamic import); handles `upgrade`
+  - Option `disableWebSocket` to force HTTP‑only mode (useful for deployments and tests)
   - HTTP interface:
     - `GET` without `clientId` → returns `{ clientId }` (handshake)
     - `GET ?poll=true&clientId=...` → returns queued messages or 204
-    - `POST` with a serialized `MsgWrapper` → enqueues/dispatches; returns immediate response message if present or 202
+    - `POST` with a serialized `MsgWrapper` → enqueues/dispatches; after a brief wait, returns any queued messages as an array (e.g. immediate response and broadcasts) or 202 when none
     - CORS preflight support
   - Associates each `clientId` with a server `HttpStrategy` (extends `HttpStrategyBase`) and registers connections with the router
 
@@ -92,9 +95,14 @@ This document describes the current, implemented architecture of Neorest.
 
 ### End‑to‑End Flows (from tests)
 
-- HTTP: `Client('http://host', 'http')` ↔ `NodeRouter`
+- HTTP: `Client('http://host', 'http' | 'auto')` ↔ `NodeRouter`
   - `GET /ping` → `"pong"`
   - `POST /echo` → echoes payload
+
+- Auto (HTTP‑first with WS upgrade): `Client('http://host', 'auto')` ↔ `NodeRouter`
+  - Immediately connects via HTTP long‑polling; upgrades to WS if available
+  - Sends prefer WS once connected; if WS send fails, transparently falls back to HTTP POST
+  - Subscriptions and broadcasts delivered over active transports
 
 - WebSocket: `Client('ws://host', 'websocket')` ↔ `NodeRouter`
   - Request/response as above
@@ -132,6 +140,8 @@ await ws.post('/messages', { text: 'hello' });
 ### Notes
 
 - WebSocket support on Node is optional; install `ws` to enable it at runtime.
+- You can force HTTP‑only mode by passing `disableWebSocket: true` to `NodeRouter` options.
 - Client routes disallow `:`; the server internally supports parameterized routes like `/topic/:name` for matching and validation.
+- HTTP `POST` responses may return an array of messages (e.g., immediate response and queued broadcasts). The client HTTP strategy handles both single and array payloads.
 
 

--- a/packages/neorest/src/Client.ts
+++ b/packages/neorest/src/Client.ts
@@ -20,7 +20,7 @@ export class Client {
    * @param strategyType - The type of strategy to use
    * @param options - Options for the connection
    */
-  constructor(url: string, strategyType: 'websocket' | 'http' = 'websocket', options?: ConnectionOptions) {
+  constructor(url: string, strategyType: 'websocket' | 'http' | 'auto' = 'auto', options?: ConnectionOptions) {
     if (!url) {
       throw new Error("URL is required to create a client connection");
     }
@@ -51,7 +51,7 @@ export class Client {
    * @param strategyType - The type of strategy to use
    * @returns A promise that resolves when the connection is established
    */
-  public async setUrl(url: string, strategyType?: 'websocket' | 'http'): Promise<void> {
+  public async setUrl(url: string, strategyType?: 'websocket' | 'http' | 'auto'): Promise<void> {
     return this.conn.setUrl(url, strategyType);
   }
 

--- a/packages/neorest/src/ClientConnection.ts
+++ b/packages/neorest/src/ClientConnection.ts
@@ -76,7 +76,7 @@ export class ClientConnection extends ConnectionBase {
    * @param url - The URL to connect to
    * @param strategyType - The type of strategy to use
    */
-  public async setUrl(url: string, strategyType?: 'websocket' | 'http'): Promise<void> {
+  public async setUrl(url: string, strategyType?: 'websocket' | 'http' | 'auto'): Promise<void> {
     this.url = url;
     
     // Close existing connection
@@ -113,14 +113,14 @@ export class ClientConnection extends ConnectionBase {
    * Get the strategy type
    * @returns The strategy type
    */
-  public getStrategyType(): 'websocket' | 'http' {
+  public getStrategyType(): 'websocket' | 'http' | 'auto' {
     const type = (this.strategy as any).type;
-    if (type === 'websocket' || type === 'http') {
+    if (type === 'websocket' || type === 'http' || type === 'auto') {
       return type;
     }
     
-    // Default to websocket
-    return 'websocket';
+    // Default to auto
+    return 'auto';
   }
 
   /**

--- a/packages/neorest/src/index.ts
+++ b/packages/neorest/src/index.ts
@@ -4,6 +4,7 @@ export { Client } from './Client';
 // Export strategies for advanced usage
 export { WebSocketStrategy } from './strategies/WebSocketStrategy';
 export { HttpStrategy } from './strategies/HttpStrategy';
+export { AutoStrategy } from './strategies/AutoStrategy';
 export { createStrategy } from './strategies';
 
 // Export connection class for advanced usage

--- a/packages/neorest/src/strategies/AutoStrategy.ts
+++ b/packages/neorest/src/strategies/AutoStrategy.ts
@@ -1,0 +1,166 @@
+import { ClientStrategy, MsgWrapper, ConnectionInfo } from '@neorest/core';
+import { WebSocketStrategy } from './WebSocketStrategy';
+import { HttpStrategy } from './HttpStrategy';
+
+/**
+ * Auto strategy: start with HTTP long-polling, attempt WebSocket upgrade, and fallback to HTTP on failures.
+ */
+export class AutoStrategy implements ClientStrategy {
+  private http: HttpStrategy;
+  private ws: WebSocketStrategy | null = null;
+
+  private messageCallback: ((message: MsgWrapper) => void) | null = null;
+  private closeCallback: (() => void) | null = null;
+  private openCallback: (() => void) | null = null;
+
+  private authData: Record<string, string> = {};
+  private connectionInfo: ConnectionInfo;
+
+  constructor(private baseUrl: string) {
+    this.http = new HttpStrategy(this.ensureHttpUrl(baseUrl));
+    this.connectionInfo = {
+      id: Math.random().toString(36).substring(2, 15),
+      url: baseUrl,
+      type: 'http',
+      status: 'disconnected'
+    };
+  }
+
+  async connect(): Promise<void> {
+    // 1) Connect HTTP first
+    await this.http.connect();
+    this.connectionInfo.status = 'connected';
+    this.connectionInfo.type = 'http';
+
+    // wire callbacks to HTTP
+    if (this.messageCallback) this.http.onMessage(this.messageCallback);
+    if (this.closeCallback) this.http.onClose(() => this.handleUnderlyingClose('http'));
+    if (this.openCallback) this.http.onOpen(() => this.handleUnderlyingOpen('http'));
+
+    // Fire open for HTTP immediately (http strategy already calls its open callback)
+    // but ensure the consumer's onOpen is invoked at least once
+    if (this.openCallback) this.openCallback();
+
+    // 2) In background, try WS upgrade
+    void this.tryUpgradeToWebSocket();
+  }
+
+  disconnect(): void {
+    try { this.ws?.disconnect(); } catch {}
+    try { this.http.disconnect(); } catch {}
+    this.connectionInfo.status = 'disconnected';
+  }
+
+  send(message: MsgWrapper): void {
+    // Prefer WS if connected; otherwise HTTP
+    if (this.ws && this.ws.isConnected()) {
+      try {
+        this.ws.send(message);
+        this.connectionInfo.type = 'websocket';
+        return;
+      } catch (e) {
+        // fallback to HTTP
+      }
+    }
+
+    // HTTP path
+    this.http.send(message);
+    this.connectionInfo.type = 'http';
+  }
+
+  onMessage(callback: (message: MsgWrapper) => void): void {
+    this.messageCallback = callback;
+    this.http.onMessage(callback);
+    if (this.ws) this.ws.onMessage(callback);
+  }
+
+  onClose(callback: () => void): void {
+    this.closeCallback = callback;
+    this.http.onClose(() => this.handleUnderlyingClose('http'));
+    if (this.ws) this.ws.onClose(() => this.handleUnderlyingClose('ws'));
+  }
+
+  onOpen(callback: () => void): void {
+    this.openCallback = callback;
+    // If underlying are already set, wire them
+    this.http.onOpen(() => this.handleUnderlyingOpen('http'));
+    if (this.ws) this.ws.onOpen(() => this.handleUnderlyingOpen('ws'));
+  }
+
+  isConnected(): boolean {
+    return (this.ws?.isConnected?.() ?? false) || this.http.isConnected();
+  }
+
+  setAuthentication(authData: Record<string, string>): void {
+    this.authData = authData;
+    this.http.setAuthentication(authData);
+    if (this.ws) this.ws.setAuthentication(authData);
+  }
+
+  getConnectionInfo(): ConnectionInfo {
+    return {
+      ...this.connectionInfo,
+      url: this.baseUrl,
+      status: this.isConnected() ? 'connected' : 'disconnected',
+      type: this.ws?.isConnected() ? 'websocket' : 'http',
+    };
+  }
+
+  // Internals
+  private async tryUpgradeToWebSocket(): Promise<void> {
+    try {
+      const wsUrl = this.ensureWsUrl(this.baseUrl);
+      const ws = new WebSocketStrategy(wsUrl);
+      // propagate auth if set
+      if (Object.keys(this.authData).length > 0) ws.setAuthentication(this.authData);
+
+      // wire message/open/close to existing callbacks
+      if (this.messageCallback) ws.onMessage(this.messageCallback);
+      if (this.openCallback) ws.onOpen(() => this.handleUnderlyingOpen('ws'));
+      if (this.closeCallback) ws.onClose(() => this.handleUnderlyingClose('ws'));
+
+      await ws.connect();
+
+      // Mark as upgraded
+      this.ws = ws;
+      this.connectionInfo.type = 'websocket';
+      // Trigger consumer open callback again to allow client to send DATA_SET over WS too
+      if (this.openCallback) this.openCallback();
+    } catch (e) {
+      // WS not available or failed; continue on HTTP silently
+    }
+  }
+
+  private handleUnderlyingOpen(kind: 'http' | 'ws'): void {
+    // Update reported type based on the latest connected kind
+    if (kind === 'ws') {
+      this.connectionInfo.type = 'websocket';
+    } else if (!this.ws || !this.ws.isConnected()) {
+      this.connectionInfo.type = 'http';
+    }
+  }
+
+  private handleUnderlyingClose(kind: 'http' | 'ws'): void {
+    // Only emit close if both transports are down
+    const wsConnected = this.ws?.isConnected() ?? false;
+    const httpConnected = this.http.isConnected();
+    if (!wsConnected && !httpConnected) {
+      if (this.closeCallback) this.closeCallback();
+      this.connectionInfo.status = 'disconnected';
+    }
+  }
+
+  private ensureHttpUrl(url: string): string {
+    if (url.startsWith('http://') || url.startsWith('https://')) return url;
+    if (url.startsWith('ws://')) return 'http://' + url.slice('ws://'.length);
+    if (url.startsWith('wss://')) return 'https://' + url.slice('wss://'.length);
+    return url;
+  }
+
+  private ensureWsUrl(url: string): string {
+    if (url.startsWith('ws://') || url.startsWith('wss://')) return url;
+    if (url.startsWith('https://')) return 'wss://' + url.slice('https://'.length);
+    if (url.startsWith('http://')) return 'ws://' + url.slice('http://'.length);
+    return 'ws://' + url; // best-effort
+  }
+}

--- a/packages/neorest/src/strategies/HttpStrategy.ts
+++ b/packages/neorest/src/strategies/HttpStrategy.ts
@@ -126,8 +126,13 @@ export class HttpStrategy implements ClientStrategy {
         if (contentType && contentType.includes('application/json')) {
           const responseData = await response.json();
           if (responseData && this.messageCallback) {
-            // Server POST returns a single message (or 202 with no body)
-            this.messageCallback(responseData as MsgWrapper);
+            if (Array.isArray(responseData)) {
+              for (const msg of responseData) {
+                this.messageCallback(msg as MsgWrapper);
+              }
+            } else {
+              this.messageCallback(responseData as MsgWrapper);
+            }
           }
         }
       } catch (error) {

--- a/packages/neorest/src/strategies/index.ts
+++ b/packages/neorest/src/strategies/index.ts
@@ -1,6 +1,7 @@
 import { CommunicationStrategy } from '@neorest/core';
 import { WebSocketStrategy } from './WebSocketStrategy';
 import { HttpStrategy } from './HttpStrategy';
+import { AutoStrategy } from './AutoStrategy';
 
 /**
  * Create a strategy based on the type and URL
@@ -8,12 +9,14 @@ import { HttpStrategy } from './HttpStrategy';
  * @param url - The URL to connect to
  * @returns The strategy
  */
-export function createStrategy(type: 'websocket' | 'http', url: string): CommunicationStrategy {
+export function createStrategy(type: 'websocket' | 'http' | 'auto', url: string): CommunicationStrategy {
   switch (type) {
     case 'websocket':
       return new WebSocketStrategy(url);
     case 'http':
       return new HttpStrategy(url);
+    case 'auto':
+      return new AutoStrategy(url);
     default:
       throw new Error(`Unsupported strategy type: ${type}`);
   }

--- a/packages/router-node/src/adapters/NodeServerAdapter.ts
+++ b/packages/router-node/src/adapters/NodeServerAdapter.ts
@@ -19,6 +19,10 @@ export interface NodeServerAdapterOptions {
     key: string;
     cert: string;
   };
+  /**
+   * When true, do not setup WebSocket server or upgrade handling.
+   */
+  disableWebSocket?: boolean;
 }
 
 /**
@@ -57,18 +61,22 @@ export class NodeServerAdapter implements ServerAdapter {
       this.server = createHttpServer((req, res) => this.handleHttpRequest(req, res));
     }
 
-    // Try to set up WebSocket server bound to the HTTP server, if 'ws' is available
-    try {
-      const { WebSocketServer } = await import('ws');
-      this.wsServer = new WebSocketServer({ noServer: true });
+    // Try to set up WebSocket server bound to the HTTP server, if 'ws' is available and not disabled
+    if (!this.options.disableWebSocket) {
+      try {
+        const { WebSocketServer } = await import('ws');
+        this.wsServer = new WebSocketServer({ noServer: true });
 
-      this.server.on('upgrade', (request: IncomingMessage, socket, head) => {
-        this.wsServer!.handleUpgrade(request, socket as any, head, async (ws: any) => {
-          await this.handleWebSocketConnection(ws, request);
+        this.server.on('upgrade', (request: IncomingMessage, socket, head) => {
+          this.wsServer!.handleUpgrade(request, socket as any, head, async (ws: any) => {
+            await this.handleWebSocketConnection(ws, request);
+          });
         });
-      });
-    } catch (err) {
-      // 'ws' not installed; skip WebSocket support
+      } catch (err) {
+        // 'ws' not installed; skip WebSocket support
+        this.wsServer = null;
+      }
+    } else {
       this.wsServer = null;
     }
 
@@ -222,14 +230,14 @@ export class NodeServerAdapter implements ServerAdapter {
           // Wait briefly for a response
           await new Promise(resolve => setTimeout(resolve, 50));
           
-          // Return any immediate response
+          // Return any immediate response (and any queued messages, including broadcasts)
           const responseMessages = strategy!.getQueuedMessages();
           if (responseMessages.length > 0) {
             res.writeHead(200, {
               'Content-Type': 'application/json',
               'Access-Control-Allow-Origin': '*'
             });
-            res.end(JSON.stringify(responseMessages[0]));
+            res.end(JSON.stringify(responseMessages));
           } else {
             res.writeHead(202, {
               'Access-Control-Allow-Origin': '*'

--- a/packages/tests/auto-fallback.test.ts
+++ b/packages/tests/auto-fallback.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { NodeRouter } from '@neorest/router-node';
+import { Client } from 'neorest';
+
+async function startServerHttpOnly(port = 8102, received: any[] = []) {
+  const router = new NodeRouter({ port, disableWebSocket: true });
+
+  router
+    .onGet('/ping', async (ctx) => { ctx.response = 'pong'; })
+    .onPost('/echo', async (ctx) => { ctx.response = ctx.data; })
+    .onPost('/send', async (ctx) => {
+      received.push(ctx.data);
+      ctx.response = 'ok';
+      router.broadcastPost('/topic/news', { from: 'server', payload: ctx.data });
+    });
+
+  router.onValidateBroadcast('/topic/:name', () => true);
+
+  await router.listen();
+  return router;
+}
+
+describe('auto strategy falls back to HTTP long-poll when WS unavailable', () => {
+  it('completes request/response and subscriptions via HTTP only', async () => {
+    const port = 8102;
+    const receivedOnServer: any[] = [];
+    const server = await startServerHttpOnly(port, receivedOnServer);
+    let client: Client | null = null;
+
+    try {
+      client = new Client(`http://localhost:${port}`, 'auto');
+      await (client as any).conn.connect();
+
+      const pong = await client.get('/ping');
+      expect(pong.data).toBe('pong');
+
+      const payload = { hello: 'fallback' };
+      const echo = await client.post<typeof payload>('/echo', payload);
+      expect(echo.data.hello).toBe('fallback');
+
+      const broadcasts: any[] = [];
+      await client.on('/topic/news', (evt) => {
+        broadcasts.push(evt.data);
+      });
+
+      const msgs = [{ n: 1 }, { n: 2 }];
+      for (const m of msgs) {
+        const res = await client.post('/send', m);
+        expect(res.error).toBeUndefined();
+      }
+
+      const waitUntil = async (cond: () => boolean, timeoutMs = 3500) => {
+        const start = Date.now();
+        while (!cond()) {
+          if (Date.now() - start > timeoutMs) break;
+          await new Promise((r) => setTimeout(r, 25));
+        }
+      };
+
+      await waitUntil(() => broadcasts.length >= 2);
+
+      expect(receivedOnServer).toEqual([{ n: 1 }, { n: 2 }]);
+      expect(broadcasts.length).toBe(2);
+      expect(broadcasts[0]).toEqual({ from: 'server', payload: { n: 1 } });
+      expect(broadcasts[1]).toEqual({ from: 'server', payload: { n: 2 } });
+    } finally {
+      try { (client as any)?.close?.(); } catch {}
+      await (server as any).close();
+    }
+  });
+});

--- a/packages/tests/auto.test.ts
+++ b/packages/tests/auto.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { NodeRouter } from '@neorest/router-node';
+import { Client } from 'neorest';
+
+async function startServer(port = 8101, received: any[] = []) {
+  const router = new NodeRouter({ port });
+
+  router
+    .onGet('/ping', async (ctx) => { ctx.response = 'pong'; })
+    .onPost('/echo', async (ctx) => { ctx.response = ctx.data; })
+    .onPost('/send', async (ctx) => {
+      received.push(ctx.data);
+      ctx.response = 'ok';
+      router.broadcastPost('/topic/news', { from: 'server', payload: ctx.data });
+    });
+
+  router.onValidateBroadcast('/topic/:name', () => true);
+
+  await router.listen();
+  return router;
+}
+
+describe('neorest client ↔ node server (auto strategy: http first, ws upgrade)', () => {
+  it('performs GET/POST over initial HTTP and receives broadcasts (upgrade if WS available)', async () => {
+    const port = 8101;
+    const receivedOnServer: any[] = [];
+    const server = await startServer(port, receivedOnServer);
+    let client: Client | null = null;
+
+    try {
+      client = new Client(`http://localhost:${port}`, 'auto');
+      await (client as any).conn.connect();
+
+      // Initial request/response (should work over HTTP immediately)
+      const pong = await client.get('/ping');
+      expect(pong.data).toBe('pong');
+
+      const payload = { hello: 'auto' };
+      const echo = await client.post<typeof payload>('/echo', payload);
+      expect(echo.data.hello).toBe('auto');
+
+      // Subscribe and verify broadcasts arrive (via WS if upgraded, otherwise via HTTP long-poll)
+      const broadcasts: any[] = [];
+      await client.on('/topic/news', (evt) => {
+        broadcasts.push(evt.data);
+      });
+
+      const msgs = [{ n: 1 }, { n: 2 }];
+      for (const m of msgs) {
+        const res = await client.post('/send', m);
+        expect(res.error).toBeUndefined();
+      }
+
+      // Wait until broadcasts received (HTTP long-poll may take up to ~1s)
+      const waitUntil = async (cond: () => boolean, timeoutMs = 3000) => {
+        const start = Date.now();
+        while (!cond()) {
+          if (Date.now() - start > timeoutMs) break;
+          await new Promise((r) => setTimeout(r, 25));
+        }
+      };
+      await waitUntil(() => broadcasts.length >= 2);
+
+      expect(receivedOnServer).toEqual([{ n: 1 }, { n: 2 }]);
+      expect(broadcasts.length).toBe(2);
+      expect(broadcasts[0]).toEqual({ from: 'server', payload: { n: 1 } });
+      expect(broadcasts[1]).toEqual({ from: 'server', payload: { n: 2 } });
+    } finally {
+      try { (client as any)?.close?.(); } catch {}
+      await (server as any).close();
+    }
+  });
+});


### PR DESCRIPTION
Add an 'auto' communication strategy for clients to use WebSocket with HTTP long-polling fallback.

---
<a href="https://cursor.com/background-agent?bcId=bc-467d08bf-8dcb-4784-8e42-0dd8e37dcf2b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-467d08bf-8dcb-4784-8e42-0dd8e37dcf2b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

