### PR TITLE
Test and fix conflicting paths

### DIFF
--- a/packages/router-core/src/Router.ts
+++ b/packages/router-core/src/Router.ts
@@ -70,6 +70,7 @@ interface InRouteLayer {
   regexp: RegExp;
   match: MatchFunction;
   keys: string[];
+  specificity: number;
   verbs: Array<{
     verb: RouteVerb;
     handler: (ctx: RequestContext) => void | Promise<void>;
@@ -85,6 +86,7 @@ interface OutRouteLayer {
   regexp: RegExp;
   match: MatchFunction;
   keys: string[];
+  specificity: number;
   listeners: Array<{
     conn: ConnectionSecret;
     params: string[];
@@ -382,6 +384,23 @@ export class Router {
     };
   }
 
+  private computeSpecificityScore(route: string, keys: string[]): number {
+    const segments = route.split('/').filter(Boolean);
+    let staticSegments = 0;
+    let wildcardSegments = 0;
+    for (const seg of segments) {
+      if (seg.includes('*')) {
+        wildcardSegments += 1;
+      } else if (!seg.startsWith(':')) {
+        staticSegments += 1;
+      }
+    }
+    const paramSegments = keys.length;
+    const lengthScore = Math.min(route.length, 999);
+    // Higher is more specific.
+    return staticSegments * 10000 - paramSegments * 100 - wildcardSegments * 1000 + lengthScore;
+  }
+
   /**
    * Register an incoming route
    * @param route - The route pattern
@@ -406,16 +425,20 @@ export class Router {
     }
 
     if (!targetRoute) {
+      const keyNames = keys.map((k) => String(k.name));
       targetRoute = {
         id: this.nextRouteSubID++,
         route,
         regexp,
         match: match(regexp, { decode: decodeURIComponent }),
-        keys: keys.map((k) => String(k.name)),
+        keys: keyNames,
+        specificity: this.computeSpecificityScore(route, keyNames),
         verbs: [],
       };
 
       this.inRoutes.push(targetRoute);
+      // Keep routes ordered by specificity (most specific first)
+      this.inRoutes.sort((a, b) => b.specificity - a.specificity);
     }
 
     const verbAndHandler = targetRoute.verbs.find((vh) => vh.verb === verb);
@@ -457,17 +480,21 @@ export class Router {
     }
 
     if (!targetRoute) {
+      const keyNames = keys.map((k) => String(k.name));
       targetRoute = {
         id: this.nextRouteSubID++,
         route,
         regexp,
         match: match(regexp, { decode: decodeURIComponent }),
-        keys: keys.map((k) => String(k.name)),
+        keys: keyNames,
+        specificity: this.computeSpecificityScore(route, keyNames),
         listeners: [],
         validate,
       };
 
       this.outRoutes.push(targetRoute);
+      // Keep routes ordered by specificity (most specific first)
+      this.outRoutes.sort((a, b) => b.specificity - a.specificity);
     }
 
     return targetRoute.id;
@@ -483,14 +510,23 @@ export class Router {
       throw new Error(`Connection with id ${connSecret} does not exist`);
     }
 
+    // Find the most specific matching route and subscribe only to that
+    let best: { route: OutRouteLayer; params: string[] } | null = null;
     for (const route of this.outRoutes) {
-      const match = route.match(path);
-      if (match) {
-        route.listeners.push({
-          conn: connSecret,
-          params: Object.values(match.params),
-        });
+      const m = route.match(path);
+      if (m) {
+        const params = Object.values(m.params);
+        if (!best || route.specificity > best.route.specificity) {
+          best = { route, params };
+        }
       }
+    }
+
+    if (best) {
+      best.route.listeners.push({
+        conn: connSecret,
+        params: best.params,
+      });
     }
   }
 
@@ -504,6 +540,7 @@ export class Router {
       throw new Error(`Connection with id ${connSecret} does not exist`);
     }
 
+    // Remove from any matching route (in case of prior multiple subscriptions)
     for (const route of this.outRoutes) {
       const match = route.match(path);
       if (match) {

--- a/packages/tests/path-conflicts.test.ts
+++ b/packages/tests/path-conflicts.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import { NodeRouter } from '@neorest/router-node';
+import { Client } from 'neorest';
+
+async function startServer(port: number, register: (router: NodeRouter) => void) {
+  const router = new NodeRouter({ port });
+  register(router);
+  await router.listen();
+  return router;
+}
+
+describe('path conflict resolution (static vs parameterized)', () => {
+  it('prefers static over parameterized when both match (param registered first)', async () => {
+    const port = 8111;
+    const server = await startServer(port, (router) => {
+      router
+        .onGet('/users/:id', async (ctx) => { ctx.response = `param:${ctx.params.id}`; })
+        .onGet('/users/new', async (ctx) => { ctx.response = 'static'; });
+    });
+
+    let client: Client | null = null;
+    try {
+      client = new Client(`http://localhost:${port}`, 'http');
+      await (client as any).conn.connect();
+
+      const res1 = await client.get('/users/new');
+      expect(res1.data).toBe('static');
+
+      const res2 = await client.get('/users/123');
+      expect(res2.data).toBe('param:123');
+    } finally {
+      try { (client as any)?.close?.(); } catch {}
+      await (server as any).close();
+    }
+  });
+
+  it('prefers static over parameterized when both match (static registered first)', async () => {
+    const port = 8112;
+    const server = await startServer(port, (router) => {
+      router
+        .onGet('/users/new', async (ctx) => { ctx.response = 'static'; })
+        .onGet('/users/:id', async (ctx) => { ctx.response = `param:${ctx.params.id}`; });
+    });
+
+    let client: Client | null = null;
+    try {
+      client = new Client(`http://localhost:${port}`, 'http');
+      await (client as any).conn.connect();
+
+      const res1 = await client.get('/users/new');
+      expect(res1.data).toBe('static');
+
+      const res2 = await client.get('/users/999');
+      expect(res2.data).toBe('param:999');
+    } finally {
+      try { (client as any)?.close?.(); } catch {}
+      await (server as any).close();
+    }
+  });
+
+  it('avoids duplicate broadcast subscriptions when static and param out routes both exist', async () => {
+    const port = 8113;
+    const server = await startServer(port, (router) => {
+      router
+        .onPost('/send', async (ctx) => {
+          ctx.response = 'ok';
+          router.broadcastPost('/topic/news', { hello: 'world' });
+        });
+
+      router.onValidateBroadcast('/topic/:name', () => true);
+      router.onValidateBroadcast('/topic/news', () => true);
+    });
+
+    let client: Client | null = null;
+    try {
+      client = new Client(`http://localhost:${port}`, 'auto');
+      await (client as any).conn.connect();
+
+      const received: any[] = [];
+      await client.on('/topic/news', (evt) => {
+        received.push(evt.data);
+      });
+
+      // Trigger two broadcasts
+      await client.post('/send', {});
+      await client.post('/send', {});
+
+      // Wait for up to ~2s for 2 messages
+      const waitUntil = async (cond: () => boolean, timeoutMs = 2000) => {
+        const start = Date.now();
+        while (!cond()) {
+          if (Date.now() - start > timeoutMs) break;
+          await new Promise((r) => setTimeout(r, 25));
+        }
+      };
+      await waitUntil(() => received.length >= 2);
+
+      expect(received.length).toBe(2);
+      expect(received[0]).toEqual({ hello: 'world' });
+      expect(received[1]).toEqual({ hello: 'world' });
+    } finally {
+      try { (client as any)?.close?.(); } catch {}
+      await (server as any).close();
+    }
+  });
+});


### PR DESCRIPTION
Add route specificity logic and tests to resolve conflicting paths, ensuring static routes are preferred and preventing duplicate broadcast subscriptions.

---
<a href="https://cursor.com/background-agent?bcId=bc-2a19e930-c508-4414-9708-890ee377aafe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2a19e930-c508-4414-9708-890ee377aafe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

