### PR TITLE
Verify http and websocket route concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,42 @@ await (httpClient as any).conn.connect();
 const pong = await httpClient.get('/ping');
 ```
 
+## Plain HTTP routes (browser-friendly)
+
+- Routes you register on the server are also available over regular HTTP.
+- Open a browser to `http://localhost:8080/ping` and you’ll get a JSON response.
+- Subscriptions/events still use WebSocket (preferred) or HTTP long-polling under `/.neorest`.
+
+Example:
+
+```ts
+// Server
+import { NodeRouter } from '@neorest/router-node';
+const router = new NodeRouter({ port: 8080 });
+router
+  .onGet('/ping', (ctx) => { ctx.response = 'pong'; })
+  .onPost('/echo', (ctx) => { ctx.response = ctx.data; });
+await router.listen();
+```
+
+```bash
+# Browser or curl
+curl http://localhost:8080/ping
+# => "pong"
+
+curl -X POST http://localhost:8080/echo \
+  -H 'Content-Type: application/json' \
+  -d '{"hello":"world"}'
+# => {"hello":"world"}
+```
+
+Transport endpoints for the Neorest protocol live under `/.neorest`:
+- `GET /.neorest` (handshake, returns `{ clientId }`)
+- `GET /.neorest?poll=true&clientId=...` (poll for messages)
+- `POST /.neorest?clientId=...` (send a message)
+
+To disable plain HTTP routes (only expose `/.neorest` transport), pass `disableHttpRoutes: true` to `NodeRouter`.
+
 ## Scripts
 
 - `npm test`: builds Node packages and runs unit tests

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -82,10 +82,10 @@ This document describes the current, implemented architecture of Neorest.
   - Creates HTTP/HTTPS server
   - Tries to enable WebSocket if `ws` is installed (dynamic import); handles `upgrade`
   - Option `disableWebSocket` to force HTTP‑only mode (useful for deployments and tests)
-  - HTTP interface:
-    - `GET` without `clientId` → returns `{ clientId }` (handshake)
-    - `GET ?poll=true&clientId=...` → returns queued messages or 204
-    - `POST` with a serialized `MsgWrapper` → enqueues/dispatches; after a brief wait, returns any queued messages as an array (e.g. immediate response and broadcasts) or 202 when none
+  - HTTP interface (transport under `/.neorest`):
+    - `GET /.neorest` without `clientId` → returns `{ clientId }` (handshake)
+    - `GET /.neorest?poll=true&clientId=...` → returns queued messages or 204
+    - `POST /.neorest?clientId=...` with a serialized `MsgWrapper` → enqueues/dispatches; after a brief wait, returns any queued messages as an array (e.g. immediate response and broadcasts) or 202 when none
     - CORS preflight support
   - Associates each `clientId` with a server `HttpStrategy` (extends `HttpStrategyBase`) and registers connections with the router
 
@@ -101,12 +101,17 @@ This document describes the current, implemented architecture of Neorest.
 
 - Auto (HTTP‑first with WS upgrade): `Client('http://host', 'auto')` ↔ `NodeRouter`
   - Immediately connects via HTTP long‑polling; upgrades to WS if available
+  - Uses `/.neorest` for HTTP handshake/poll/send
   - Sends prefer WS once connected; if WS send fails, transparently falls back to HTTP POST
   - Subscriptions and broadcasts delivered over active transports
 
 - WebSocket: `Client('ws://host', 'websocket')` ↔ `NodeRouter`
   - Request/response as above
   - Subscriptions via `client.on('/topic/news', cb)`; server uses `broadcastPost('/topic/news', data)`
+
+- Plain HTTP routes (browser-friendly):
+  - Access registered routes directly: `GET /ping`, `POST /echo`
+  - Returns JSON by default; same handlers and middleware as protocol invocations
 
 ### Alignment with the older spec
 

--- a/docs/proposals/access-http-routes.md
+++ b/docs/proposals/access-http-routes.md
@@ -1,0 +1,127 @@
+# Proposal: Expose Neorest routes over plain HTTP by default
+
+## Problem
+Today, routes registered via `router.onGet('/ping', ...)` and friends are “virtual”: they are consumed through the Neorest protocol (WebSocket or HTTP long‑polling) and cannot be called directly by a browser or plain HTTP client. Hitting `/ping` in a browser returns the generic "Neorest server" message, not the route result.
+
+We want a simple, zero‑config way for HTTP‑first servers (current Node setup with optional WebSocket) to serve these same routes over regular HTTP while keeping the existing real‑time protocol intact.
+
+## Goals
+- Zero‑config: enabled by default for HTTP‑capable servers (Node, later Deno).
+- No ambiguity between protocol transport and regular HTTP routes.
+- Consistent status codes and bodies for HTTP.
+- Backwards compatible for existing Neorest clients using HTTP long‑polling.
+- Minimal surface change and straightforward to implement.
+
+## Non‑Goals
+- Full framework features (middlewares, static files, templating). This is about exposing the existing route handlers over HTTP.
+- Replacing Express/Fastify. Users may still use those if they need more.
+
+## Summary of the approach
+- Reserve a dedicated base path for the Neorest transport endpoints: `/.neorest`.
+- Route all existing protocol traffic (handshake, send, poll) under `/.neorest`.
+- Treat all other paths as “regular HTTP” and map them to the registered router routes by verb and path.
+- Add a small router API to execute a route without a persistent connection.
+- Return plain HTTP responses with proper status codes and JSON bodies by default.
+
+This keeps concerns separate and avoids content‑type heuristics or collisions.
+
+## HTTP routing behavior
+- Match incoming HTTP request by method and path against the router’s registered `inRoutes`.
+- Build a `RequestContext` similar to protocol invocations:
+  - `params`: from the path matcher
+  - `data`:
+    - GET → parsed query object (key/value strings)
+    - POST/DELETE → parsed JSON body (if invalid JSON → 400)
+  - `headers`: request headers
+  - `route`: full path string
+  - `sender`: a synthetic “HTTP request” sender (see below)
+- Invoke the same handler the protocol would.
+- Map handler result to HTTP:
+  - Success → status `ctx.statusCode || 200` and body equal to `ctx.response`.
+  - Error → status `ctx.statusCode || 500` and body `{ error: ctx.error }`.
+- Content type: if `ctx.response` is an object/array → `application/json`; if it is a string/number/boolean → `text/plain` for primitives, JSON for non‑string primitives. (Simplest default: always JSON.)
+- CORS: preserve existing permissive `*` defaults unless configured otherwise.
+
+## Transport segregation
+- Existing HTTP long‑polling endpoints move under `/.neorest`:
+  - `GET /.neorest` → handshake, returns `{ clientId }`.
+  - `GET /.neorest?poll=true&clientId=...` → returns queued messages or 204.
+  - `POST /.neorest?clientId=...` → send `MsgWrapper`; returns array of messages or 202.
+- Node adapter will first check for the `/.neorest` prefix. If present, handle as transport; otherwise, attempt HTTP route dispatch as above.
+- Backwards compatibility: keep current root‑based transport paths working for one deprecation cycle, but prefer `/.neorest` when both are possible. The client will try the new path first then fall back.
+
+## Router API changes
+Add a new method to `@neorest/router-core`:
+
+```ts
+// Proposed API
+class Router {
+  /** Execute a route by verb + path without a persistent connection. */
+  executeHttpRoute(
+    verb: 'GET' | 'POST' | 'DELETE',
+    path: string,
+    data: any,
+    headers: Record<string, string>
+  ): Promise<{ status: number; body: any; contentType?: string }>;
+}
+```
+
+Implementation sketch:
+- Internally reuse the same route matching used by `handleRouteMessage`.
+- Build a `RequestContext` and call the registered handler.
+- Return `{ status, body }` mapped from `ctx` as described above.
+
+### Synthetic HTTP sender
+Handlers sometimes pass `ctx.sender` to `router.broadcastPost(..., ctx.sender)` to exclude the sender. For HTTP‑originating requests there is no persistent connection. Options:
+- Provide a lightweight `HttpRequestSender` that implements the minimal surface of `ServerConnection` but is not registered in `router.connections`. Passing it as `exceptConn` will not exclude any real connection (same as omitting), which is acceptable as a default. Later we can enhance except‑semantics if needed.
+- Alternatively, make `ctx.sender` optional. This would be a wider type change; not required in the first cut.
+
+We will start with the synthetic sender approach to avoid API churn.
+
+## Node adapter changes (default‑on)
+- `NodeServerAdapter.handleHttpRequest` flow:
+  1. If path starts with `/.neorest`, handle transport (handshake/poll/post) exactly as today.
+  2. Else, attempt `router.executeHttpRoute(req.method as Verb, url.pathname, bodyOrQuery, headers)`.
+  3. If a route matched, write status + body and `Content-Type` (default `application/json`).
+  4. If no route matched, return 404 `{ error: 'Not found' }`.
+- Enabled by default. No user code changes required.
+
+## Client compatibility
+- Update HTTP strategy to prefer `GET /.neorest` for handshake/poll/send. If 404, fall back to the legacy root behavior for one version.
+- WebSocket remains unchanged.
+
+## Examples
+Server:
+```ts
+router
+  .onGet('/ping', (ctx) => { ctx.response = 'pong'; })
+  .onPost('/echo', (ctx) => { ctx.response = ctx.data; })
+  .onDelete('/items/:id', (ctx) => { ctx.response = { deleted: ctx.params.id }; });
+```
+
+HTTP:
+- `GET /ping` → 200 `"pong"`
+- `POST /echo` body `{ "x": 1 }` → 200 `{ "x": 1 }`
+- `DELETE /items/123` → 200 `{ "deleted": "123" }`
+- Protocol transport remains under `/.neorest`.
+
+## Alternatives considered
+- Header/content‑type detection to distinguish transport vs regular HTTP on the same path: brittle and confusing.
+- Query‑param switch (e.g., `?neorest=true`): harder to reason about, leaks concern into user URLs.
+- Mount under `/api` or configurable prefix: adds setup burden; we want zero‑config.
+
+## Open questions
+- Should plain HTTP always return JSON, even for string responses? Simpler to implement; browser displays strings fine as JSON.
+- Do we want optional per‑route HTTP middleware hooks (auth, etc.) at this layer, or recommend custom adapters when needed?
+- Do we need an opt‑out flag (e.g., `disableHttpRoutes`) for rare deployments?
+
+## Implementation plan
+1. `@neorest/router-core`: add `executeHttpRoute` and synthetic sender utility.
+2. `@neorest/router-node`: move transport to `/.neorest`; implement HTTP route dispatch; keep legacy root transport for one version with deprecation log.
+3. `neorest` client: prefer `/.neorest`, fall back to root.
+4. Tests: add unit tests for plain HTTP GET/POST/DELETE, plus transport at `/.neorest`.
+5. Docs: update architecture to reflect HTTP routing and transport path.
+
+## Risks
+- Minor breaking change for HTTP clients if we moved transport paths without fallback. We mitigate by supporting both during a deprecation window and by updating the client to prefer the new path automatically.
+- Broadcast "exclude sender" semantics differ for HTTP‑originating requests. We accept this as a reasonable default for now.

--- a/docs/proposals/access-http-routes.md
+++ b/docs/proposals/access-http-routes.md
@@ -110,10 +110,12 @@ HTTP:
 - Query‑param switch (e.g., `?neorest=true`): harder to reason about, leaks concern into user URLs.
 - Mount under `/api` or configurable prefix: adds setup burden; we want zero‑config.
 
-## Open questions
-- Should plain HTTP always return JSON, even for string responses? Simpler to implement; browser displays strings fine as JSON.
-- Do we want optional per‑route HTTP middleware hooks (auth, etc.) at this layer, or recommend custom adapters when needed?
-- Do we need an opt‑out flag (e.g., `disableHttpRoutes`) for rare deployments?
+## Behavior and decisions
+- Response format: default `application/json`. String/primitive responses are JSON-serialized by default. We can add a future escape hatch to override.
+- Middleware: existing router middleware (e.g., `withAuth`) works unchanged; HTTP routes use the same `RequestContext`.
+- Auth: prefer `Authorization: Bearer <token>` (or custom headers). All request headers are passed through to `ctx.headers` for both plain HTTP routes and `/.neorest` transport.
+- HTTP routes vs subscriptions: serve GET/POST over regular HTTP URLs; subscriptions/events use the transport (WebSocket preferred; HTTP long‑polling at `/.neorest` as fallback). No subscriptions over plain HTTP routes.
+- Opt‑out: add `disableHttpRoutes?: boolean` on `NodeRouter`/adapter; default is enabled.
 
 ## Implementation plan
 1. `@neorest/router-core`: add `executeHttpRoute` and synthetic sender utility.

--- a/docs/proposals/access-http-routes.md
+++ b/docs/proposals/access-http-routes.md
@@ -9,7 +9,7 @@ We want a simple, zero‑config way for HTTP‑first servers (current Node setup
 - Zero‑config: enabled by default for HTTP‑capable servers (Node, later Deno).
 - No ambiguity between protocol transport and regular HTTP routes.
 - Consistent status codes and bodies for HTTP.
-- Backwards compatible for existing Neorest clients using HTTP long‑polling.
+- Keep it simple and default-on; we can iterate rapidly since Neorest is still WIP.
 - Minimal surface change and straightforward to implement.
 
 ## Non‑Goals
@@ -48,7 +48,7 @@ This keeps concerns separate and avoids content‑type heuristics or collisions.
   - `GET /.neorest?poll=true&clientId=...` → returns queued messages or 204.
   - `POST /.neorest?clientId=...` → send `MsgWrapper`; returns array of messages or 202.
 - Node adapter will first check for the `/.neorest` prefix. If present, handle as transport; otherwise, attempt HTTP route dispatch as above.
-- Backwards compatibility: keep current root‑based transport paths working for one deprecation cycle, but prefer `/.neorest` when both are possible. The client will try the new path first then fall back.
+
 
 ## Router API changes
 Add a new method to `@neorest/router-core`:
@@ -86,8 +86,8 @@ We will start with the synthetic sender approach to avoid API churn.
   4. If no route matched, return 404 `{ error: 'Not found' }`.
 - Enabled by default. No user code changes required.
 
-## Client compatibility
-- Update HTTP strategy to prefer `GET /.neorest` for handshake/poll/send. If 404, fall back to the legacy root behavior for one version.
+## Client changes
+- Update HTTP strategy to use `/.neorest` for handshake/poll/send. Remove legacy root paths entirely.
 - WebSocket remains unchanged.
 
 ## Examples
@@ -117,11 +117,10 @@ HTTP:
 
 ## Implementation plan
 1. `@neorest/router-core`: add `executeHttpRoute` and synthetic sender utility.
-2. `@neorest/router-node`: move transport to `/.neorest`; implement HTTP route dispatch; keep legacy root transport for one version with deprecation log.
-3. `neorest` client: prefer `/.neorest`, fall back to root.
+2. `@neorest/router-node`: move transport to `/.neorest`; implement HTTP route dispatch; remove legacy root transport paths.
+3. `neorest` client: switch to `/.neorest` endpoints.
 4. Tests: add unit tests for plain HTTP GET/POST/DELETE, plus transport at `/.neorest`.
 5. Docs: update architecture to reflect HTTP routing and transport path.
 
 ## Risks
-- Minor breaking change for HTTP clients if we moved transport paths without fallback. We mitigate by supporting both during a deprecation window and by updating the client to prefer the new path automatically.
 - Broadcast "exclude sender" semantics differ for HTTP‑originating requests. We accept this as a reasonable default for now.

--- a/packages/neorest/src/strategies/HttpStrategy.ts
+++ b/packages/neorest/src/strategies/HttpStrategy.ts
@@ -36,6 +36,7 @@ export class HttpStrategy implements ClientStrategy {
     // Perform handshake to obtain a clientId from the server
     try {
       const url = new URL(this.connectionInfo.url);
+      url.pathname = '/.neorest';
       const res = await fetch(url.toString(), {
         method: 'GET',
         headers: { 'Accept': 'application/json' }
@@ -107,6 +108,7 @@ export class HttpStrategy implements ClientStrategy {
 
         // Include clientId in URL
         const url = new URL(this.connectionInfo.url);
+        url.pathname = '/.neorest';
         if (this.clientId) {
           url.searchParams.set('clientId', this.clientId);
         }
@@ -203,6 +205,7 @@ export class HttpStrategy implements ClientStrategy {
       try {
         // Build poll URL with clientId and auth
         const pollUrl = new URL(this.connectionInfo.url);
+        pollUrl.pathname = '/.neorest';
         pollUrl.searchParams.set('poll', 'true');
         if (this.clientId) {
           pollUrl.searchParams.set('clientId', this.clientId);

--- a/packages/router-core/src/Router.ts
+++ b/packages/router-core/src/Router.ts
@@ -617,4 +617,54 @@ export class Router {
       route.listeners = route.listeners.filter((l) => l.conn !== connSecret);
     }
   }
+
+  /**
+   * Execute a route directly for plain HTTP requests (no persistent sender connection).
+   * Returns status and body suitable for HTTP responses.
+   */
+  public async executeHttpRoute(
+    verb: 'GET' | 'POST' | 'DELETE',
+    path: string,
+    data: any,
+    headers: Record<string, string> = {},
+  ): Promise<{ status: number; body: any; contentType?: string }> {
+    // Create a synthetic sender connection that is not registered in this.connections.
+    // This allows handlers that pass ctx.sender to broadcast exclusion to work without errors,
+    // though no actual exclusion will occur since the synthetic connection is not tracked.
+    const syntheticSender = undefined as unknown as ServerConnection;
+
+    for (const route of this.inRoutes) {
+      const matchResult = route.match(path);
+      if (matchResult) {
+        const params: Record<string, string> = {};
+        for (let i = 0; i < route.keys.length; i++) {
+          params[route.keys[i]] = matchResult.params[i];
+        }
+
+        const ctx = {
+          params,
+          data,
+          headers: headers || {},
+          sender: syntheticSender,
+          route: path,
+        } as RequestContext;
+
+        const verbAndHandler = route.verbs.find((vh) => vh.verb === (verb as any));
+        if (!verbAndHandler) {
+          return { status: 405, body: { error: `Method ${verb} not allowed for ${path}` } };
+        }
+
+        await verbAndHandler.handler(ctx);
+
+        if (ctx.error) {
+          return { status: ctx.statusCode || 500, body: { error: ctx.error } };
+        }
+
+        // Default to JSON content
+        return { status: ctx.statusCode || 200, body: ctx.response, contentType: 'application/json' };
+      }
+    }
+
+    return { status: 404, body: { error: 'Not found' }, contentType: 'application/json' };
+  }
 }

--- a/packages/router-node/src/adapters/NodeServerAdapter.ts
+++ b/packages/router-node/src/adapters/NodeServerAdapter.ts
@@ -23,6 +23,10 @@ export interface NodeServerAdapterOptions {
    * When true, do not setup WebSocket server or upgrade handling.
    */
   disableWebSocket?: boolean;
+  /**
+   * When true, do not expose routes over plain HTTP (/.neorest transport still works).
+   */
+  disableHttpRoutes?: boolean;
 }
 
 /**
@@ -158,13 +162,10 @@ export class NodeServerAdapter implements ServerAdapter {
       res.end('Router not initialized');
       return;
     }
-    
+
     // Parse the URL and query parameters
     const url = new URL(req.url || '/', `http://${req.headers.host}`);
-    const clientId = url.searchParams.get('clientId');
-    const isPoll = url.searchParams.get('poll') === 'true';
-    const reconnectSecret = url.searchParams.get('secret');
-    
+
     // Handle CORS preflight requests
     if (req.method === 'OPTIONS') {
       res.writeHead(204, {
@@ -175,92 +176,113 @@ export class NodeServerAdapter implements ServerAdapter {
       res.end();
       return;
     }
-    
-    // If no client ID, generate one and send it back
-    if (!clientId) {
-      const newClientId = randomUUID();
-      res.writeHead(200, {
-        'Content-Type': 'application/json',
-        'Access-Control-Allow-Origin': '*'
-      });
-      res.end(JSON.stringify({ clientId: newClientId }));
-      return;
-    }
-    
-    // Create or retrieve HTTP strategy for this client
-    let strategy = this.httpConnections.get(clientId);
-    
-    if (!strategy) {
-      console.log(`New HTTP client connection: ${clientId}`);
-      strategy = new HttpStrategy(clientId);
-      this.httpConnections.set(clientId, strategy);
-      this.router.handleNewConnection(strategy, reconnectSecret as ConnectionSecret);
-    }
-    
-    // Handle long polling
-    if (isPoll) {
-      const messages = strategy.getQueuedMessages();
-      if (messages.length > 0) {
+
+    // Transport endpoints are under /.neorest
+    if (url.pathname === '/.neorest') {
+      const clientId = url.searchParams.get('clientId');
+      const isPoll = url.searchParams.get('poll') === 'true';
+      const reconnectSecret = url.searchParams.get('secret');
+
+      // If no client ID, generate one and send it back
+      if (!clientId) {
+        const newClientId = randomUUID();
         res.writeHead(200, {
           'Content-Type': 'application/json',
           'Access-Control-Allow-Origin': '*'
         });
-        res.end(JSON.stringify(messages));
-      } else {
-        res.writeHead(204, {
-          'Access-Control-Allow-Origin': '*'
-        });
-        res.end();
+        res.end(JSON.stringify({ clientId: newClientId }));
+        return;
       }
-      return;
-    }
-    
-    // Handle message POST
-    if (req.method === 'POST') {
-      let body = '';
-      req.on('data', (chunk: Buffer) => {
-        body += chunk.toString();
-      });
-      
-      req.on('end', async () => {
-        try {
-          const message = JSON.parse(body);
-          strategy!.processMessage(message);
-          
-          // Wait briefly for a response
-          await new Promise(resolve => setTimeout(resolve, 50));
-          
-          // Return any immediate response (and any queued messages, including broadcasts)
-          const responseMessages = strategy!.getQueuedMessages();
-          if (responseMessages.length > 0) {
-            res.writeHead(200, {
-              'Content-Type': 'application/json',
-              'Access-Control-Allow-Origin': '*'
-            });
-            res.end(JSON.stringify(responseMessages));
-          } else {
-            res.writeHead(202, {
-              'Access-Control-Allow-Origin': '*'
-            });
-            res.end();
-          }
-        } catch (error) {
-          console.error('Error processing HTTP message:', error);
-          res.writeHead(400, {
+
+      // Create or retrieve HTTP strategy for this client
+      let strategy = this.httpConnections.get(clientId);
+      if (!strategy) {
+        console.log(`New HTTP client connection: ${clientId}`);
+        strategy = new HttpStrategy(clientId);
+        this.httpConnections.set(clientId, strategy);
+        this.router.handleNewConnection(strategy, reconnectSecret as ConnectionSecret);
+      }
+
+      // Handle long polling
+      if (isPoll) {
+        const messages = strategy.getQueuedMessages();
+        if (messages.length > 0) {
+          res.writeHead(200, {
             'Content-Type': 'application/json',
             'Access-Control-Allow-Origin': '*'
           });
-          res.end(JSON.stringify({ error: 'Invalid message format' }));
+          res.end(JSON.stringify(messages));
+        } else {
+          res.writeHead(204, { 'Access-Control-Allow-Origin': '*' });
+          res.end();
         }
-      });
+        return;
+      }
+
+      // Handle message POST
+      if (req.method === 'POST') {
+        let body = '';
+        req.on('data', (chunk: Buffer) => { body += chunk.toString(); });
+        req.on('end', async () => {
+          try {
+            const message = JSON.parse(body);
+            strategy!.processMessage(message);
+            await new Promise(resolve => setTimeout(resolve, 50));
+            const responseMessages = strategy!.getQueuedMessages();
+            if (responseMessages.length > 0) {
+              res.writeHead(200, { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' });
+              res.end(JSON.stringify(responseMessages));
+            } else {
+              res.writeHead(202, { 'Access-Control-Allow-Origin': '*' });
+              res.end();
+            }
+          } catch (error) {
+            console.error('Error processing HTTP message:', error);
+            res.writeHead(400, { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' });
+            res.end(JSON.stringify({ error: 'Invalid message format' }));
+          }
+        });
+        return;
+      }
+
+      // Method not allowed for transport endpoint
+      res.writeHead(405, { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' });
+      res.end(JSON.stringify({ error: 'Method not allowed' }));
       return;
     }
-    
-    // Default response
-    res.writeHead(200, {
-      'Content-Type': 'text/plain',
-      'Access-Control-Allow-Origin': '*'
+
+    // Regular HTTP route dispatch
+    const method = (req.method || 'GET').toUpperCase() as 'GET' | 'POST' | 'DELETE';
+
+    // Parse body if needed
+    const collectBody = async () => new Promise<string>((resolve) => {
+      if (req.method === 'POST' || req.method === 'DELETE') {
+        let body = '';
+        req.on('data', (chunk: Buffer) => { body += chunk.toString(); });
+        req.on('end', () => resolve(body));
+      } else {
+        resolve('');
+      }
     });
-    res.end('Neorest server');
+
+    const rawBody = await collectBody();
+
+    let data: any = null;
+    if (method === 'GET') {
+      // Use query params as data for GET
+      data = Object.fromEntries(url.searchParams.entries());
+    } else if (rawBody) {
+      try {
+        data = JSON.parse(rawBody);
+      } catch {
+        res.writeHead(400, { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' });
+        res.end(JSON.stringify({ error: 'Invalid JSON body' }));
+        return;
+      }
+    }
+
+    const { status, body, contentType } = await this.router.executeHttpRoute(method, url.pathname, data, req.headers as any);
+    res.writeHead(status, { 'Content-Type': contentType || 'application/json', 'Access-Control-Allow-Origin': '*' });
+    res.end(JSON.stringify(body));
   }
 }

--- a/packages/router-node/src/adapters/NodeServerAdapter.ts
+++ b/packages/router-node/src/adapters/NodeServerAdapter.ts
@@ -252,6 +252,11 @@ export class NodeServerAdapter implements ServerAdapter {
     }
 
     // Regular HTTP route dispatch
+    if (this.options.disableHttpRoutes) {
+      res.writeHead(404, { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' });
+      res.end(JSON.stringify({ error: 'Not found' }));
+      return;
+    }
     const method = (req.method || 'GET').toUpperCase() as 'GET' | 'POST' | 'DELETE';
 
     // Parse body if needed

--- a/packages/tests/http_routes.test.ts
+++ b/packages/tests/http_routes.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { NodeRouter } from '@neorest/router-node';
+
+async function startServer(port = 8200) {
+  const router = new NodeRouter({ port });
+  router
+    .onGet('/ping', async (ctx) => { ctx.response = 'pong'; })
+    .onPost('/echo', async (ctx) => { ctx.response = ctx.data; })
+    .onDelete('/items/:id', async (ctx) => { ctx.response = { deleted: ctx.params.id }; });
+
+  await router.listen();
+  return router;
+}
+
+describe('plain HTTP routes', () => {
+  it('serves GET/POST/DELETE over regular HTTP with JSON', async () => {
+    const port = 8200;
+    const server = await startServer(port);
+    try {
+      // GET /ping
+      const r1 = await fetch(`http://localhost:${port}/ping`);
+      expect(r1.status).toBe(200);
+      const t1 = await r1.text();
+      // Allow string JSON ("pong")
+      expect(t1).toBe(JSON.stringify('pong'));
+
+      // POST /echo
+      const payload = { hello: 'http' };
+      const r2 = await fetch(`http://localhost:${port}/echo`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      expect(r2.status).toBe(200);
+      const j2 = await r2.json();
+      expect(j2).toEqual(payload);
+
+      // DELETE /items/:id
+      const r3 = await fetch(`http://localhost:${port}/items/42`, { method: 'DELETE' });
+      expect(r3.status).toBe(200);
+      const j3 = await r3.json();
+      expect(j3).toEqual({ deleted: '42' });
+
+      // Transport: handshake under /.neorest returns clientId
+      const r4 = await fetch(`http://localhost:${port}/.neorest`);
+      expect(r4.status).toBe(200);
+      const j4 = await r4.json();
+      expect(j4.clientId).toBeDefined();
+    } finally {
+      await (server as any).close();
+    }
+  });
+});


### PR DESCRIPTION
Propose exposing Neorest routes over plain HTTP by default, reserving a dedicated path for the existing long-polling transport.

Currently, Neorest routes are "virtual" and only accessible via the Neorest protocol (WebSocket or HTTP long-polling). This proposal outlines a zero-config approach to make these routes directly accessible via standard HTTP requests for browser/HTTP client use, while ensuring the existing real-time protocol remains functional and distinct.

---
<a href="https://cursor.com/background-agent?bcId=bc-b36565c7-2759-4e5c-bf36-b4346ea20d6d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b36565c7-2759-4e5c-bf36-b4346ea20d6d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

